### PR TITLE
Add avatar for site owner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ owner:
   name: Eugene Belilovsky
   bio: "Researcher in Machine Learning"
   email: Belilovsky.Eugene@gmail.com
+  avatar: myphoto3.jpg
 
 include:
   - _pages


### PR DESCRIPTION
## Summary
- specify an avatar image for the site owner so the bio photo renders on pages

## Testing
- bundle exec jekyll build *(fails: jekyll not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693add0b18b88322bed1bcc40cdf420e)