### PR TITLE
Widen page content and highlight group link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,6 +8,7 @@
   
 - title: Group
   url: /Students/
+  class: nav-cta
   
 - title: Software
   url: https://github.com/eugenium

--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -4,16 +4,21 @@
 	</div><!-- /.site-name -->
 	<div class="top-navigation">
 		<nav role="navigation" id="site-nav" class="nav">
-		    <ul>
-		        {% for link in site.data.navigation %}
-				    {% if link.url contains 'http' %}
-				        {% assign domain = '' %}
-				        {% else %}
-				        {% assign domain = site.url %}
-				    {% endif %}
-				    <li><a href="{{ domain }}{{ link.url }}" {% if link.url contains 'http' %}target="_blank"{% endif %}>{{ link.title }}</a></li>
-				{% endfor %}
-		    </ul>
-		</nav>
-	</div><!-- /.top-navigation -->
+                    <ul>
+                        {% for link in site.data.navigation %}
+                                    {% if link.url contains 'http' %}
+                                        {% assign domain = '' %}
+                                        {% else %}
+                                        {% assign domain = site.url %}
+                                    {% endif %}
+                                    <li>
+                                        <a
+                                          href="{{ domain }}{{ link.url }}"
+                                          class="{% if link.class %}{{ link.class }}{% endif %}"
+                                          {% if link.url contains 'http' %}target="_blank"{% endif %}>{{ link.title }}</a>
+                                    </li>
+                                {% endfor %}
+                    </ul>
+                </nav>
+        </div><!-- /.top-navigation -->
 </div><!-- /.navigation-wrapper -->

--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -79,18 +79,43 @@ body {
 			white-space: nowrap;
 			border-bottom: 0 solid transparent;
 		}
-		a { 
-			display: block;
-			padding: 10px 0;
-			decoration: none;
-			border-bottom: 0 solid transparent;
-			@include transition(all .2s);
-			@media #{$small} {
-				display: inline;
-				padding: 0;
-			}
-		}
-	}
+                a {
+                        display: block;
+                        padding: 10px 0;
+                        decoration: none;
+                        border-bottom: 0 solid transparent;
+                        @include transition(all .2s);
+                        @media #{$small} {
+                                display: inline;
+                                padding: 0;
+                        }
+                        &.nav-cta {
+                                display: inline-block;
+                                padding: 10px 16px;
+                                margin-top: 6px;
+                                border-radius: 999px;
+                                background: $basecolor;
+                                color: $white;
+                                font-weight: 700;
+                                letter-spacing: 0.02em;
+                                box-shadow: 0 8px 18px rgba($basecolor,0.25);
+                                @media #{$small} {
+                                        padding: 8px 16px;
+                                        margin-top: 0;
+                                }
+                                &:hover,
+                                &:focus,
+                                &:visited {
+                                        color: $white;
+                                }
+                                &:hover,
+                                &:focus {
+                                        background: darken($basecolor, 8);
+                                        box-shadow: 0 10px 22px rgba($basecolor,0.35);
+                                }
+                        }
+                }
+        }
 }
 
 /* Animated lines for mobile nav button */
@@ -223,26 +248,27 @@ $button-size: 1.5rem;
 	@include clearfix;
 	clear: both;
 	margin-top: 2em;
-	h1 {
-		margin-top: 0;
-	}
-	.post,
-	.page {
-		@include container;
-		@include grid(12,20);
-		@include prefix(12,1);
-		@include suffix(12,1);
-		margin-bottom: 2em;
-		@media #{$small} {
-			@include grid(12,6);
-			@include prefix(12,0);
-			@include suffix(12,0);
-		}
-		@media #{$x-large} {
-			@include grid(12,4.5);
-		}
-	}
-	
+        h1 {
+                margin-top: 0;
+        }
+        .post,
+        .page {
+                @include container;
+                @include grid(12,12);
+                @include prefix(12,0);
+                @include suffix(12,0);
+                margin: 0 auto 2em;
+                max-width: 1100px;
+                padding: 0 1.5rem;
+                @media #{$small} {
+                        max-width: 1250px;
+                        padding: 0 2rem;
+                }
+                @media #{$x-large} {
+                        max-width: 1400px;
+                }
+        }
+
 }
 
 /* Index listing specific styling */


### PR DESCRIPTION
## Summary
- widen the main page/post content area with larger max widths and padding for improved readability across wide browsers
- allow navigation links to supply custom classes and style the Group link as a pill-shaped call to action

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b8f9cdb188322811488de0707a5e2)