### PR TITLE
Enhance navigation and spruce up group and publications pages

### DIFF
--- a/Publications/index.md
+++ b/Publications/index.md
@@ -2,36 +2,68 @@
 layout: page
 title: Publications
 excerpt: "Publications"
-classes: wide
+classes: "wide publications-page"
 share: false
 ---
 
+<div class="publications-page">
+  <div class="pub-hero">
+    <p class="lead">A selection of recent work. For a comprehensive, up-to-date list, visit my <a href="https://scholar.google.com/citations?user=CffJDoEAAAAJ&amp;hl=en">Google Scholar profile</a>.</p>
+  </div>
 
-
-My full and update list of publications can be found [Google Scholar profile](https://scholar.google.com/citations?user=CffJDoEAAAAJ&hl=en)
-
-## Selected Publications
-
-* MohammadReza Davari, Nader Asadi, Sudhir Mudur, Rahaf Aljundi, **Eugene Belilovsky**:
-Probing representation forgetting in supervised and unsupervised continual learning. CVPR 2022. [PDF](https://openaccess.thecvf.com/content/CVPR2022/html/Davari_Probing_Representation_Forgetting_in_Supervised_and_Unsupervised_Continual_Learning_CVPR_2022_paper.html) 
-
-* Nasir Khalid, Tianhao Xie, **Eugene Belilovsky**, Tiberiu Popa:
-CLIP-Mesh: Generating textured meshes from text using pretrained image-text models. SIGGRAPH Asia 2022. [PDF](https://arxiv.org/abs/2203.13333) [[Code](https://www.nasir.lol/clipmesh)]
-
-* Mateusz Michalkiewicz, Sarah Parisot, Stavros Tsogkas, Mahsa Baktashmotlagh, Anders P. Eriksson, **Eugene Belilovsky**:
-Few-Shot Single-View 3-D Object Reconstruction with Compositional Priors. ECCV 2020. [PDF](https://arxiv.org/pdf/2004.06302.pdf) [[Code](https://github.com/JeremyFisher/few_shot_3dr)]
-
-* Rahaf Aljundi\*, Lucas Caccia\*, **Eugene Belilovsky**\*, Massimo Caccia\*, Min Lin, Laurent Charlin, Tinne Tuytelaars: Online Continual Learning with Maximally Inferred Retrieval.  NeurIPS 2019. \*Equal Contribution [PDF](https://arxiv.org/abs/1908.04742) [[Code](https://github.com/optimass/Maximally_Interfered_Retrieval)]
-
-* **Eugene Belilovsky**, Michael Eickenberg, Edouard Oyallon: Decoupled Greedy Learning of CNNs. ICML 2020. [PDF](https://arxiv.org/abs/1901.08164) [[Code](https://github.com/eugenium/DGL)]
-
-* **Eugene Belilovsky**, Michael Eickenberg, Edouard Oyallon: Greedy Layerwise Learning Can Scale to ImageNet.  ICML 2019. [PDF](https://arxiv.org/pdf/1812.11446.pdf) [[Code](https://github.com/eugenium/layerCNN)]
-
-* Edouard Oyallon, **Eugene Belilovsky**,Sergey Zagoruyko: Scaling the Scattering Transform: Deep Hybrid Networks. ICCV 2017. <i class="fa fa-file-pdf-o"></i> [PDF](https://arxiv.org/pdf/1703.08961.pdf)<small> [[Code](https://github.com/edouardoyallon/scalingscattering)]</small>
-
-* **Eugene Belilovsky**, Kyle Kastner, Gael Varoquaux, Matthew B. Blaschko: Learning to Discover Sparse Graphical Model Structures. ICML 2017. <i class="fa fa-file-pdf-o"></i> [PDF](https://arxiv.org/pdf/1605.06359.pdf)<small> [[Code](https://github.com/eugenium/LearnGraphDiscovery)]</small>
-
-
-* **Eugene Belilovsky**, Gael Varoquaux, Matthew B. Blaschko, : Testing for Differences in Gaussian Graphical Models: Applications to Brain Connectivity. NIPS 2016. <i class="fa fa-file-pdf-o"></i> [PDF](https://arxiv.org/pdf/1512.08643.pdf)<small> [[Code](https://github.com/eugenium/EdgeDifferenceTest)]</small>
-
-* **Eugene Belilovsky**\*, Wacha Bounliphone\*, Matthew Blaschko, Ioannis Antonoglou, Arthur Gretton : A Test of Relative Similarity For Model Selection in Generative Models . ICLR 2016. <i class="fa fa-file-pdf-o"></i> [PDF](http://arxiv.org/pdf/1511.04581.pdf) <small>[[Code](https://github.com/eugenium/MMD)]</small>
+  <section class="pub-section">
+    <h2>Selected Publications</h2>
+    <ol class="pub-list">
+    <li>
+      <h3>Probing representation forgetting in supervised and unsupervised continual learning</h3>
+      <p class="pub-meta">MohammadReza Davari, Nader Asadi, Sudhir Mudur, Rahaf Aljundi, <strong>Eugene Belilovsky</strong> &mdash; CVPR 2022</p>
+      <p class="pub-links"><a href="https://openaccess.thecvf.com/content/CVPR2022/html/Davari_Probing_Representation_Forgetting_in_Supervised_and_Unsupervised_Continual_Learning_CVPR_2022_paper.html">PDF</a></p>
+    </li>
+    <li>
+      <h3>CLIP-Mesh: Generating textured meshes from text using pretrained image-text models</h3>
+      <p class="pub-meta">Nasir Khalid, Tianhao Xie, <strong>Eugene Belilovsky</strong>, Tiberiu Popa &mdash; SIGGRAPH Asia 2022</p>
+      <p class="pub-links"><a href="https://arxiv.org/abs/2203.13333">PDF</a> &middot; <a href="https://www.nasir.lol/clipmesh">Code</a></p>
+    </li>
+    <li>
+      <h3>Few-Shot Single-View 3-D Object Reconstruction with Compositional Priors</h3>
+      <p class="pub-meta">Mateusz Michalkiewicz, Sarah Parisot, Stavros Tsogkas, Mahsa Baktashmotlagh, Anders P. Eriksson, <strong>Eugene Belilovsky</strong> &mdash; ECCV 2020</p>
+      <p class="pub-links"><a href="https://arxiv.org/pdf/2004.06302.pdf">PDF</a> &middot; <a href="https://github.com/JeremyFisher/few_shot_3dr">Code</a></p>
+    </li>
+    <li>
+      <h3>Online Continual Learning with Maximally Inferred Retrieval</h3>
+      <p class="pub-meta">Rahaf Aljundi*, Lucas Caccia*, <strong>Eugene Belilovsky</strong>*, Massimo Caccia*, Min Lin, Laurent Charlin, Tinne Tuytelaars &mdash; NeurIPS 2019 (*equal contribution)</p>
+      <p class="pub-links"><a href="https://arxiv.org/abs/1908.04742">PDF</a> &middot; <a href="https://github.com/optimass/Maximally_Interfered_Retrieval">Code</a></p>
+    </li>
+    <li>
+      <h3>Decoupled Greedy Learning of CNNs</h3>
+      <p class="pub-meta"><strong>Eugene Belilovsky</strong>, Michael Eickenberg, Edouard Oyallon &mdash; ICML 2020</p>
+      <p class="pub-links"><a href="https://arxiv.org/abs/1901.08164">PDF</a> &middot; <a href="https://github.com/eugenium/DGL">Code</a></p>
+    </li>
+    <li>
+      <h3>Greedy Layerwise Learning Can Scale to ImageNet</h3>
+      <p class="pub-meta"><strong>Eugene Belilovsky</strong>, Michael Eickenberg, Edouard Oyallon &mdash; ICML 2019</p>
+      <p class="pub-links"><a href="https://arxiv.org/pdf/1812.11446.pdf">PDF</a> &middot; <a href="https://github.com/eugenium/layerCNN">Code</a></p>
+    </li>
+    <li>
+      <h3>Scaling the Scattering Transform: Deep Hybrid Networks</h3>
+      <p class="pub-meta">Edouard Oyallon, <strong>Eugene Belilovsky</strong>, Sergey Zagoruyko &mdash; ICCV 2017</p>
+      <p class="pub-links"><a href="https://arxiv.org/pdf/1703.08961.pdf">PDF</a> &middot; <a href="https://github.com/edouardoyallon/scalingscattering">Code</a></p>
+    </li>
+    <li>
+      <h3>Learning to Discover Sparse Graphical Model Structures</h3>
+      <p class="pub-meta"><strong>Eugene Belilovsky</strong>, Kyle Kastner, Gael Varoquaux, Matthew B. Blaschko &mdash; ICML 2017</p>
+      <p class="pub-links"><a href="https://arxiv.org/pdf/1605.06359.pdf">PDF</a> &middot; <a href="https://github.com/eugenium/LearnGraphDiscovery">Code</a></p>
+    </li>
+    <li>
+      <h3>Testing for Differences in Gaussian Graphical Models: Applications to Brain Connectivity</h3>
+      <p class="pub-meta"><strong>Eugene Belilovsky</strong>, Gael Varoquaux, Matthew B. Blaschko &mdash; NIPS 2016</p>
+      <p class="pub-links"><a href="https://arxiv.org/pdf/1512.08643.pdf">PDF</a> &middot; <a href="https://github.com/eugenium/EdgeDifferenceTest">Code</a></p>
+    </li>
+    <li>
+      <h3>A Test of Relative Similarity For Model Selection in Generative Models</h3>
+      <p class="pub-meta"><strong>Eugene Belilovsky</strong>*, Wacha Bounliphone*, Matthew Blaschko, Ioannis Antonoglou, Arthur Gretton &mdash; ICLR 2016 (*equal contribution)</p>
+      <p class="pub-links"><a href="http://arxiv.org/pdf/1511.04581.pdf">PDF</a> &middot; <a href="https://github.com/eugenium/MMD">Code</a></p>
+    </li>
+    </ol>
+  </section>
+</div>

--- a/Students/index.md
+++ b/Students/index.md
@@ -1,79 +1,99 @@
 ---
-layout: single
-classes: wide
+layout: page
 title: Students
+classes: "wide group-page"
 share: false
 ---
 
-I am leading a research group currently focused on the following themes<br>
-1) Large scale communication-efficient pre-training - including model parallelism, data parallelism, and privacy and heterogeneity in federated learning<br>
-2) Distribution shifts - including topics such as continual learning and domain adaptation<br>
-3) Learning more efficient optimizers (learned optimizers)
+<div class="group-hero">
+  <p class="lead">I lead a research group exploring modern, scalable learning systems. We focus on communication-efficient pre-training, robustness to distribution shifts, and learning better optimizers.</p>
+  <ul class="pill-list">
+    <li>Communication-efficient pre-training (model &amp; data parallelism, privacy, federated heterogeneity)</li>
+    <li>Distribution shifts (continual learning, domain adaptation)</li>
+    <li>Learned optimizers</li>
+  </ul>
+</div>
 
-Our group members: 
+<div class="group-sections">
+  <section class="group-card">
+    <h2>PhD Students</h2>
+    <ul class="plain-list">
+      <li><a href="https://davari.io">Reza Davari</a></li>
+      <li><a href="https://amoudgl.github.io/">Abhinav Moudgil</a></li>
+      <li><a href="https://scholar.google.com/citations?user=zYXzEisAAAAJ&amp;hl=es">Albert Orozco Camacho</a> (co-supervised with Guy Wolf)</li>
+      <li><a href="https://scholar.google.com/citations?user=bvNfLmMAAAAJ&amp;hl=en">Adel Nabli</a> (co-supervised with Edouard Oyallon)</li>
+      <li><a href="https://scholar.google.com/citations?hl=en&amp;user=hwERHFYAAAAJ">Gwen Legate</a></li>
+      <li><a href="https://scholar.google.com/citations?user=RbO_ULYAAAAJ&amp;hl=en">Benjamin Therien</a> (co-supervised with Irina Rish)</li>
+      <li><a href="https://scholar.google.com/citations?user=xDFiPCkAAAAJ&amp;hl=en">Vaibhav Singh</a></li>
+      <li><a href="https://scholar.google.com/citations?user=wfKn1W0AAAAJ&amp;hl=en">Paul Janson</a></li>
+      <li><a href="https://scholar.google.ca/citations?user=gBTbYKgAAAAJ&amp;hl=en">Amirhossein Zamani</a> (co-supervised with Amir Aghdam)</li>
+    </ul>
+  </section>
 
-**PhD Students**<br>
-[Reza Davari](https://davari.io)<br>
-[Abhinav Moudgil](https://amoudgl.github.io/)<br>
-[Albert Orozco Camacho](https://scholar.google.com/citations?user=zYXzEisAAAAJ&hl=es) (co-supervised with Guy Wolf)<br>
-[Adel Nabli](https://scholar.google.com/citations?user=bvNfLmMAAAAJ&hl=en)(co-supervised with Edouard Oyallon) <br>
-[Gwen Legate](https://scholar.google.com/citations?hl=en&user=hwERHFYAAAAJ)<br>
-[Benjamin Therien](https://scholar.google.com/citations?user=RbO_ULYAAAAJ&hl=en) (co-supervised with Irina Rish)<br>
-[Vaibhav Singh](https://scholar.google.com/citations?user=xDFiPCkAAAAJ&hl=en) <br>
-[Paul Janson](https://scholar.google.com/citations?user=wfKn1W0AAAAJ&hl=en) <br>
-[Amirhossein Zamani](https://scholar.google.ca/citations?user=gBTbYKgAAAAJ&hl=en)(co-supervised with Amir Aghdam)<br> 
+  <section class="group-card">
+    <h2>MSc Students</h2>
+    <ul class="plain-list">
+      <li>Paria Mehrbod (co-supervised with Guy Wolf)</li>
+      <li>Zafir Khalid</li>
+      <li>Xialong Huang</li>
+    </ul>
 
-**Msc Students**<br>
-Paria Mehrbod (co-supervised with Guy Wolf)<br>
-Zafir Khalid <br>
-Xialong Huang <br>
+    <h2>Postdoc</h2>
+    <ul class="plain-list">
+      <li><a href="https://gerald4.github.io/">Geraldin Nanfack</a></li>
+    </ul>
+  </section>
 
-**PostDoc**<br>
-[Geraldin Nanfack](https://gerald4.github.io/)<br>
+  <section class="group-card">
+    <h2>Frequent Collaborators</h2>
+    <ul class="plain-list">
+      <li>Lucas Caccia (McGill)</li>
+      <li>Rahaf Aljundi (Toyota Research)</li>
+      <li>Boris Knyazev (Samsung Research)</li>
+      <li>Guy Wolf (UdeM/Mila)</li>
+      <li>Irina Rish (UdeM/Mila)</li>
+      <li>Guillaume Lajoie (UdeM/Mila)</li>
+      <li>Michael Eickenberg (Flatiron Institute)</li>
+      <li>Edouard Oyallon (CNRS)</li>
+      <li>Tiberiu Popa (Concordia)</li>
+      <li>Aaron Courville (UdeM/Mila)</li>
+    </ul>
+  </section>
+</div>
 
-**Alumni**<br>
-Congshu Zou Msc 2025 <br>
-Humza Wajid Hameed Msc 2025 <br>
-Nicolas Bernier Msc 2025 (Now ML at Amazon)<br>
-Charles-Etienne Joseph Msc 2024 (Now Research engineer at capital one)<br>
-Alexander Fulleringer Msc 2024<br>
-[Nader Asadi](https://naderasadi.github.io/) Msc 2023 (Now ML Researcher at Huawei)<br>
-[Nasir Khalid](https://www.nasir.lol) Msc 2023 (now ML Researcher at Haven Studios)<br>
-[Amir Sarfi](https://scholar.google.com/citations?user=KcYl7zsAAAAJ&hl=en) Msc 2023 (now researcher at Slyod) <br>
-[Adeetya Patel](https://ca.linkedin.com/in/adeetyap) Msc 2023 (now RA at Mcgill University)<br> 
-[Medric Sonwa](https://github.com/medric49) Msc 2023 (now Data scientist at ONMO) <br>
-[Muawiz Chaudhary](https://scholar.google.ca/citations?hl=en&user=4Z8ePskAAAAJ)Msc 2023 <br>
-[Gwen Legate](https://scholar.google.com/citations?hl=en&user=hwERHFYAAAAJ), Msc 2023 (continued to PhD)<br>
-[Irene Tenison](https://scholar.google.com/citations?user=piW3r38AAAAJ&hl=en), Msc 2022 (now PhD student at MIT)<br>
-Benjamin Therien, NSERC Undergrad Researcher 2021 (now Msc at University of Waterloo)<br>
-Yu Xiang Zhang, NSERC Undergrad Researcher 2022 (now Software Engineer at Amazon)<br>
-Boris Knyazev, PhD Intern (now Research Scientist at Samsung Research)
+<section class="group-card">
+  <h2>Alumni</h2>
+  <ul class="plain-list two-column">
+    <li>Congshu Zou — MSc 2025</li>
+    <li>Humza Wajid Hameed — MSc 2025</li>
+    <li>Nicolas Bernier — MSc 2025 (Now ML at Amazon)</li>
+    <li>Charles-Etienne Joseph — MSc 2024 (Now Research engineer at Capital One)</li>
+    <li>Alexander Fulleringer — MSc 2024</li>
+    <li><a href="https://naderasadi.github.io/">Nader Asadi</a> — MSc 2023 (Now ML Researcher at Huawei)</li>
+    <li><a href="https://www.nasir.lol">Nasir Khalid</a> — MSc 2023 (Now ML Researcher at Haven Studios)</li>
+    <li><a href="https://scholar.google.com/citations?user=KcYl7zsAAAAJ&amp;hl=en">Amir Sarfi</a> — MSc 2023 (Now Researcher at Slyod)</li>
+    <li><a href="https://ca.linkedin.com/in/adeetyap">Adeetya Patel</a> — MSc 2023 (Now RA at McGill University)</li>
+    <li><a href="https://github.com/medric49">Medric Sonwa</a> — MSc 2023 (Now Data Scientist at ONMO)</li>
+    <li><a href="https://scholar.google.ca/citations?hl=en&amp;user=4Z8ePskAAAAJ">Muawiz Chaudhary</a> — MSc 2023</li>
+    <li><a href="https://scholar.google.com/citations?hl=en&amp;user=hwERHFYAAAAJ">Gwen Legate</a> — MSc 2023 (continued to PhD)</li>
+    <li><a href="https://scholar.google.com/citations?user=piW3r38AAAAJ&amp;hl=en">Irene Tenison</a> — MSc 2022 (Now PhD student at MIT)</li>
+    <li>Benjamin Therien — NSERC Undergrad Researcher 2021 (Now MSc at University of Waterloo)</li>
+    <li>Yu Xiang Zhang — NSERC Undergrad Researcher 2022 (Now Software Engineer at Amazon)</li>
+    <li>Boris Knyazev — PhD Intern (Now Research Scientist at Samsung Research)</li>
+  </ul>
+</section>
 
-
-
-**Frequent Collaborators**<br>
-Lucas Caccia (McGill) <br>
-Rahaf Aljundi (Toyota Research)<br>
-Boris Knyazev (Samsung Research)<br>
-Guy Wolf (UdeM/Mila)<br>
-Irina Rish (UdeM/Mila)<br>
-Guillaume Lajoie (UdeM/Mila)<br>
-Michael Eickenberg (Flatiron Institute)<br>
-Edouard Oyallon (CNRS)<br>
-Tiberiu Popa (Concordia)<br>
-Aaron Courville (UdeM/Mila)
-
-**Sponsors**<br>
-Our group is generously supported by 
-
-<img src="https://user-images.githubusercontent.com/3606031/236766516-80d2f641-ee46-422b-ac93-43da6817db2f.png" width="300" height="100" alt="image"><img src="https://user-images.githubusercontent.com/3606031/236766688-5eab14c9-a6b3-4bf1-8a1b-9a9b212597ca.png" width="250" height="100" alt="image">
-<img src="https://user-images.githubusercontent.com/3606031/236766742-d7d1431b-ffa1-423b-8886-39a9fefd1fb4.png" width="250" height="100" alt="image">
-<img src="https://user-images.githubusercontent.com/3606031/236766805-9da59062-9d00-4697-a5c8-ab21276f6b50.png" width="300" height="100" alt="image">
-<img src="https://user-images.githubusercontent.com/3606031/236766883-24b5f3d6-ca11-47f2-bafd-c7979b734eae.png" width="250" height="100" alt="image">
-<img src="https://user-images.githubusercontent.com/3606031/236767295-e33f0d43-07f7-4971-9ae5-ee9ae4cf9359.png" width="250" height="80" alt="image">
-<img src="https://user-images.githubusercontent.com/3606031/236769621-36e740d5-2964-4326-8b7e-dc549f603b08.png" width="250" height="80" alt="image"><img src="https://user-images.githubusercontent.com/3606031/236769326-756a76bf-821f-4beb-be3b-bbcbc4424657.png" width="250" height="80" alt="image">
-
-
-
-
-
+<section class="group-card sponsors">
+  <h2>Sponsors</h2>
+  <p>Our group is generously supported by:</p>
+  <div class="sponsor-logos">
+    <img src="https://user-images.githubusercontent.com/3606031/236766516-80d2f641-ee46-422b-ac93-43da6817db2f.png" alt="Logo 1" loading="lazy">
+    <img src="https://user-images.githubusercontent.com/3606031/236766688-5eab14c9-a6b3-4bf1-8a1b-9a9b212597ca.png" alt="Logo 2" loading="lazy">
+    <img src="https://user-images.githubusercontent.com/3606031/236766742-d7d1431b-ffa1-423b-8886-39a9fefd1fb4.png" alt="Logo 3" loading="lazy">
+    <img src="https://user-images.githubusercontent.com/3606031/236766805-9da59062-9d00-4697-a5c8-ab21276f6b50.png" alt="Logo 4" loading="lazy">
+    <img src="https://user-images.githubusercontent.com/3606031/236766883-24b5f3d6-ca11-47f2-bafd-c7979b734eae.png" alt="Logo 5" loading="lazy">
+    <img src="https://user-images.githubusercontent.com/360767295-e33f0d43-07f7-4971-9ae5-ee9ae4cf9359.png" alt="Logo 6" loading="lazy">
+    <img src="https://user-images.githubusercontent.com/3606031/236769621-36e740d5-2964-4326-8b7e-dc549f603b08.png" alt="Logo 7" loading="lazy">
+    <img src="https://user-images.githubusercontent.com/3606031/236769326-756a76bf-821f-4beb-be3b-bbcbc4424657.png" alt="Logo 8" loading="lazy">
+  </div>
+</section>

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,9 +5,12 @@
 
 - title: Publications
   url: /Publications/
+  class: nav-cta
   
 - title: Group
   url: /Students/
+  class: nav-cta
   
 - title: Software
   url: https://github.com/eugenium
+  class: nav-cta

--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -4,16 +4,21 @@
 	</div><!-- /.site-name -->
 	<div class="top-navigation">
 		<nav role="navigation" id="site-nav" class="nav">
-		    <ul>
-		        {% for link in site.data.navigation %}
-				    {% if link.url contains 'http' %}
-				        {% assign domain = '' %}
-				        {% else %}
-				        {% assign domain = site.url %}
-				    {% endif %}
-				    <li><a href="{{ domain }}{{ link.url }}" {% if link.url contains 'http' %}target="_blank"{% endif %}>{{ link.title }}</a></li>
-				{% endfor %}
-		    </ul>
-		</nav>
-	</div><!-- /.top-navigation -->
+                    <ul>
+                        {% for link in site.data.navigation %}
+                                    {% if link.url contains 'http' %}
+                                        {% assign domain = '' %}
+                                        {% else %}
+                                        {% assign domain = site.url %}
+                                    {% endif %}
+                                    <li>
+                                        <a
+                                          href="{{ domain }}{{ link.url }}"
+                                          class="{% if link.class %}{{ link.class }}{% endif %}"
+                                          {% if link.url contains 'http' %}target="_blank"{% endif %}>{{ link.title }}</a>
+                                    </li>
+                                {% endfor %}
+                    </ul>
+                </nav>
+        </div><!-- /.top-navigation -->
 </div><!-- /.navigation-wrapper -->

--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -3,9 +3,155 @@
    ========================================================================== */
 
 body {
-	background-color: $bodycolor;
-	font-family: $base-font;
-	color: $text-color;
+        background-color: $bodycolor;
+        font-family: $base-font;
+        color: $text-color;
+}
+
+.group-hero {
+        padding: 20px;
+        margin: 0 0 24px;
+        border-radius: 12px;
+        background: lighten($basecolor, 45);
+        border: 1px solid lighten($basecolor, 30);
+        box-shadow: 0 10px 25px rgba($black, 0.06);
+        .lead {
+                margin: 0 0 12px;
+                font-size: 1.05em;
+                line-height: 1.6;
+                color: darken($text-color, 5);
+        }
+}
+
+.pill-list {
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        list-style: none;
+        li {
+                padding: 8px 12px;
+                border-radius: 999px;
+                background: $white;
+                border: 1px solid lighten($basecolor, 25);
+                box-shadow: 0 4px 12px rgba($basecolor, 0.12);
+                font-weight: 600;
+                color: darken($text-color, 8);
+        }
+}
+
+.group-sections {
+        display: grid;
+        gap: 20px;
+        margin-bottom: 24px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.group-card {
+        padding: 20px;
+        border-radius: 14px;
+        background: $white;
+        border: 1px solid lighten($black, 85);
+        box-shadow: 0 12px 30px rgba($black, 0.05);
+        h2 {
+                margin-top: 0;
+                margin-bottom: 12px;
+        }
+}
+
+.plain-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        li {
+                margin-bottom: 8px;
+                line-height: 1.5;
+        }
+}
+
+.plain-list.two-column {
+        column-count: 2;
+        column-gap: 24px;
+        @media #{$small} {
+                column-count: 2;
+        }
+        @media #{$medium} {
+                column-count: 2;
+        }
+        @media #{$large} {
+                column-count: 3;
+        }
+}
+
+.sponsors .sponsor-logos,
+.sponsor-logos {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 16px;
+        align-items: center;
+        img {
+                max-width: 100%;
+                height: auto;
+                filter: grayscale(10%);
+                padding: 6px;
+                background: $white;
+                border-radius: 8px;
+                border: 1px solid lighten($black, 90);
+        }
+}
+
+.publications-page {
+        .article-wrap {
+                max-width: 980px;
+        }
+}
+
+.pub-hero {
+        padding: 18px 20px;
+        margin: 0 0 20px;
+        border-radius: 12px;
+        background: lighten($basecolor, 45);
+        border: 1px solid lighten($basecolor, 30);
+        box-shadow: 0 10px 25px rgba($black, 0.06);
+}
+
+.pub-section h2 {
+        margin-top: 0;
+}
+
+.pub-list {
+        list-style: decimal;
+        padding-left: 20px;
+        margin: 0;
+        display: grid;
+        gap: 18px;
+        li {
+                padding: 14px 16px;
+                border-radius: 12px;
+                border: 1px solid lighten($black, 85);
+                background: $white;
+                box-shadow: 0 10px 24px rgba($black, 0.05);
+        }
+        h3 {
+                margin: 0 0 6px;
+        }
+        .pub-meta {
+                margin: 0 0 8px;
+                color: darken($text-color, 8);
+                font-size: 0.98em;
+        }
+        .pub-links {
+                margin: 0;
+                font-weight: 600;
+                a {
+                        color: $basecolor;
+                        &:hover,
+                        &:focus {
+                                color: darken($basecolor, 8);
+                        }
+                }
+        }
 }
 
 /* 
@@ -79,18 +225,43 @@ body {
 			white-space: nowrap;
 			border-bottom: 0 solid transparent;
 		}
-		a { 
-			display: block;
-			padding: 10px 0;
-			decoration: none;
-			border-bottom: 0 solid transparent;
-			@include transition(all .2s);
-			@media #{$small} {
-				display: inline;
-				padding: 0;
-			}
-		}
-	}
+                a {
+                        display: block;
+                        padding: 10px 0;
+                        decoration: none;
+                        border-bottom: 0 solid transparent;
+                        @include transition(all .2s);
+                        @media #{$small} {
+                                display: inline;
+                                padding: 0;
+                        }
+                        &.nav-cta {
+                                display: inline-block;
+                                padding: 10px 16px;
+                                margin-top: 6px;
+                                border-radius: 999px;
+                                background: $basecolor;
+                                color: $white;
+                                font-weight: 700;
+                                letter-spacing: 0.02em;
+                                box-shadow: 0 8px 18px rgba($basecolor,0.25);
+                                @media #{$small} {
+                                        padding: 8px 16px;
+                                        margin-top: 0;
+                                }
+                                &:hover,
+                                &:focus,
+                                &:visited {
+                                        color: $white;
+                                }
+                                &:hover,
+                                &:focus {
+                                        background: darken($basecolor, 8);
+                                        box-shadow: 0 10px 22px rgba($basecolor,0.35);
+                                }
+                        }
+                }
+        }
 }
 
 /* Animated lines for mobile nav button */
@@ -223,26 +394,26 @@ $button-size: 1.5rem;
 	@include clearfix;
 	clear: both;
 	margin-top: 2em;
-	h1 {
-		margin-top: 0;
-	}
-	.post,
-	.page {
-		@include container;
-		@include grid(12,20);
-		@include prefix(12,1);
-		@include suffix(12,1);
-		margin-bottom: 2em;
-		@media #{$small} {
-			@include grid(12,6);
-			@include prefix(12,0);
-			@include suffix(12,0);
-		}
-		@media #{$x-large} {
-			@include grid(12,4.5);
-		}
-	}
-	
+        h1 {
+                margin-top: 0;
+        }
+        .post,
+        .page {
+                @include container;
+                @include grid(12,20);
+                @include prefix(12,1);
+                @include suffix(12,1);
+                margin-bottom: 2em;
+                @media #{$small} {
+                        @include grid(12,6);
+                        @include prefix(12,0);
+                        @include suffix(12,0);
+                }
+                @media #{$x-large} {
+                        @include grid(12,4.5);
+                }
+        }
+
 }
 
 /* Index listing specific styling */


### PR DESCRIPTION
## Summary
- Style Publications and Software navigation links to match the Group call-to-action look
- Refresh the Students page with structured sections, cards, and sponsor grid for clearer presentation
- Reformat the Publications page with highlighted hero, card-style entries, and wider content styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b8f9cdb188322811488de0707a5e2)