### PR TITLE
Widen layout for main, group, and publications pages

### DIFF
--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -103,7 +103,7 @@ body {
 
 .publications-page {
         .article-wrap {
-                max-width: 980px;
+                max-width: 1120px;
         }
 }
 
@@ -400,9 +400,9 @@ $button-size: 1.5rem;
         .post,
         .page {
                 @include container;
-                @include grid(12,20);
-                @include prefix(12,1);
-                @include suffix(12,1);
+                @include grid(12,11);
+                @include prefix(12,0.5);
+                @include suffix(12,0.5);
                 margin-bottom: 2em;
                 @media #{$small} {
                         @include grid(12,6);
@@ -418,11 +418,11 @@ $button-size: 1.5rem;
 
 /* Index listing specific styling */
 #index {
-	@include container;
-	@include grid(12,10);
-	@include prefix(12,1);
-	@include suffix(12,1);
-	margin-bottom: 2em;
+        @include container;
+        @include grid(12,11);
+        @include prefix(12,0.5);
+        @include suffix(12,0.5);
+        margin-bottom: 2em;
 	@media #{$small} {
 		@include grid(12,6);
 		@include prefix(12,0);


### PR DESCRIPTION
## Summary
- widen the main content grid by reducing side margins on key layouts
- expand index page width to match broader layout
- increase publications page article wrap max width for more comfortable reading

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd89a7a0083229b5f71f9731d137d)