### PR TITLE
Add CV link to navigation menu

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -14,3 +14,7 @@
 - title: Software
   url: https://github.com/eugenium
   class: nav-cta
+
+- title: CV
+  url: https://github.com/eugenium/eugenium.github.io/blob/master/images/CV_2025.pdf
+  class: nav-cta


### PR DESCRIPTION
## Summary
- add a CV tab in the navigation menu linking to the hosted CV PDF

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69421574cd908322a0bd1fe658fc7b5e)