### PR TITLE
Add 'Join the Group' navigation tab and remove homepage recruiting link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,3 +18,7 @@
 - title: CV
   url: https://drive.google.com/file/d/1omNVzGmd_AEQZa1k-4zdbPo6TaYQlDS1/view?usp=sharing
   class: nav-cta
+
+- title: Join the Group
+  url: /Projects/postdoc.html
+  class: nav-cta

--- a/index.md
+++ b/index.md
@@ -28,5 +28,3 @@ Broadly my research interests are in Efficient Training for Large Scale Deep Lea
 * I am co-organizing the workshop on "Localized Learning" at ICML 2023
 * MS Amir Sarfi has a paper accepted at CVPR 2023
 * ClipMesh is accepted at SIGGRAPH Asia 2022, see project page https://www.nasir.lol/clipmesh
-
-[Recruiting](http://eugenium.github.io/Projects/postdoc.html)


### PR DESCRIPTION
### Motivation
- Move the recruiting entry into the main site navigation as a clearly labeled tab and remove the duplicate link from the bottom of the homepage so visitors can find recruiting info via the primary nav (`/Projects/postdoc.html`).

### Description
- Added a new navigation item in `_data/navigation.yml` (`Join the Group` → `/Projects/postdoc.html`) and removed the standalone recruiting link from the homepage `index.md`.

### Testing
- Validated the file changes with `git diff`; attempted `bundle exec jekyll build` which failed because the Jekyll gems are not installed in this environment and `bundle install` failed with HTTP 403 when contacting RubyGems, so a full local site render could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0d853ac88322859c3fc3d5c515ee)